### PR TITLE
TAINT_ESCAPE_CLEAN の追加

### DIFF
--- a/lib/VulnChecker/TaintVariableRecord.php
+++ b/lib/VulnChecker/TaintVariableRecord.php
@@ -6,7 +6,9 @@ namespace VulnChecker;
 const TAINT_DITRY = 20;
 // MAYBE 外部関数呼び出しの返り値や解決できない変数などを用いている
 const TAINT_MAYBE = 10; 
-// CLEAN 文字列リテラル あるいは shellescape などを施している
+// CLEAN_ESACPE shellescape を施している
+const TAINT_ESCAPE_CLEAN = 1;
+// CLEAN 文字列リテラル等
 const TAINT_CLEAN = 0;
 
 class TaintVariableRecord

--- a/lib/VulnChecker/TaintVisitor.php
+++ b/lib/VulnChecker/TaintVisitor.php
@@ -137,7 +137,7 @@ class TaintVisitor extends NodeVisitorAbstract
     if($node->name instanceof Node\Name) {
       $name = $node->name->toString();
       if($name === 'escapeshellarg' || $name === 'escapeshellcmd'){
-        return TAINT_CLEAN;
+        return TAINT_ESCAPE_CLEAN;
       } else {
         // TODO
         return TAINT_MAYBE;


### PR DESCRIPTION
`exec` と `eval` に渡す文字列は区別すべき。
`TAINT_ESCAPE_CLEAN` を追加した。これはシェルに渡す文字列に対してはcleanであることを意味する。

比較演算子で `$tainted < TAINT_ESCAPE_CLEAN` のように使えるはず。小さいほうがCLEAN。